### PR TITLE
target.classList to target.className.split(' ')

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -159,7 +159,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 					var parentFound = false;
 
 					while (angular.isDefined(target) && target !== null && !parentFound) {
-						if (_.contains(target.classList, 'multiselect-parent') && !parentFound) {
+						if (_.contains(target.className.split(' '), 'multiselect-parent') && !parentFound) {
 							parentFound = true;
 						}
 						target = target.parentElement;


### PR DESCRIPTION
In order to support IE8 and IE9 the classList should be replaced with className.
