### PR TITLE
fix: closeOnBlur works properly with multiple dropdowns

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -54,6 +54,8 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
                 element.html(template);
             },
             link: function ($scope, $element, $attrs) {
+                var $dropdownTrigger = $element.children()[0];
+                
                 $scope.toggleDropdown = function () {
                     $scope.open = !$scope.open;
                 };
@@ -150,7 +152,9 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 
                         while (angular.isDefined(target) && target !== null && !parentFound) {
                             if (_.contains(target.className.split(' '), 'multiselect-parent') && !parentFound) {
-                                parentFound = true;
+                                if(target === $dropdownTrigger) {
+                                    parentFound = true;
+                                }
                             }
                             target = target.parentElement;
                         }


### PR DESCRIPTION
Remember exact dropdown parent on initialization.
On each document click if we're on .multiselect-parent node check if that node is that original dropdown parent.
