### PR TITLE
Added undefined check to resolve the getButtonText undefind issue. (https://github.com/dotansimha/angularjs-dropdown-multiselect/issues/22)

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -177,7 +177,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
                 };
 
                 $scope.getButtonText = function () {
-                    if ($scope.settings.dynamicTitle && ($scope.selectedModel.length > 0 || (angular.isObject($scope.selectedModel) && _.keys($scope.selectedModel).length > 0))) {
+                    if ($scope.settings.dynamicTitle && $scope.selectedModel && ($scope.selectedModel.length > 0 || (angular.isObject($scope.selectedModel) && _.keys($scope.selectedModel).length > 0))) {
                         if ($scope.settings.smartButtonMaxItems > 0) {
                             var itemsText = [];
 


### PR DESCRIPTION
https://github.com/dotansimha/angularjs-dropdown-multiselect/issues/22

'ngDropdownMultiselect' directive is getting executed before the scope binding, so the $scope.selectedModel is undefined at that time while executing the $scope.getButtonText() function, so calling the length on undefind is causing this issue.
