### PR TITLE
changed list template in support of feature request: keyboard support…

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -36,7 +36,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
                     template += '<li role="presentation" ng-repeat="option in options | filter: searchFilter">';
                 }
 
-                template += '<a role="menuitem" tabindex="-1" ng-click="setSelectedItem(getPropertyForObject(option,settings.idProp))">';
+                template += '<a href="#" role="menuitem" ng-click="setSelectedItem(getPropertyForObject(option,settings.idProp))">';                
 
                 if (checkboxes) {
                     template += '<div class="checkbox"><label><input class="checkboxInput" type="checkbox" ng-click="checkboxClick($event, getPropertyForObject(option,settings.idProp))" ng-checked="isChecked(getPropertyForObject(option,settings.idProp))" /> {{getPropertyForObject(option, settings.displayProp)}}</label></div></a>';


### PR DESCRIPTION
Adding the href attribute to the anchor tag will allow the Enter key to active the link and will trigger the associated ng-click handler. Removing tabindex=-1 will bring the link back in the natural tab order of the web page and allow the TAB and SHIFT + TAB keys to move through the list of links.

… #15 
