### PR TITLE
chore(commonjs): Add support for commonjs and npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angularjs-dropdown-multiselect.min.js');
+module.exports = 'angularjs-dropdown-multiselect';

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 	"engines": {
 		"node": ">=0.10.10"
 	},
-	"main": "dist/angularjs-dropdown-multiselect.min.js",
+	"main": "index.js",
 	"keywords": [
 		"angular",
 		"multiselect"


### PR DESCRIPTION
Added angularjs-dropdown-multiselect to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

angular.module('myApp', [require('angularjs-dropdown-multiselect')]);

This is helpful for Browserify and Webpack.