### PR TITLE
Fix keyDownToggleSearch

### DIFF
--- a/src/app/component/angularjs-dropdown-multiselect.controller.js
+++ b/src/app/component/angularjs-dropdown-multiselect.controller.js
@@ -484,7 +484,7 @@ export default function dropdownMultiselectController(
 		}
 	}
 
-	function keyDownToggleSearch() {
+	function keyDownToggleSearch(event) {
 		if (!$scope.settings.keyboardControls) {
 			return;
 		}


### PR DESCRIPTION
Method was missing an `event` parameter.
[Issue #413](https://github.com/dotansimha/angularjs-dropdown-multiselect/issues/413)