### PR TITLE
Replacing className.split with target.hasClass()

### DIFF
--- a/dist/src/angularjs-dropdown-multiselect.js
+++ b/dist/src/angularjs-dropdown-multiselect.js
@@ -218,7 +218,8 @@
 					var parentFound = false;
 
 					while (angular.isDefined(target) && target !== null && !parentFound) {
-						if (!!target.className.split && contains(target.className.split(' '), 'multiselect-parent') && !parentFound) {
+						var $target = angular.element(target)
+						if ($target.hasClass('multiselect-parent') && !parentFound) {
 							if (target === $dropdownTrigger) {
 								parentFound = true;
 							}


### PR DESCRIPTION
Instead of checking if className is an actual string in e.target object representing a DOM element (it's not a string in a highcharts graph for example or other sofisticated representations in the Document, I propose wrapping e.target with an angular provided jquery/jqlite object and use provided hasClass() method instead, which propably makes "contains" function redundant